### PR TITLE
feat unique usernames

### DIFF
--- a/onchain/src/username_store/interfaces.cairo
+++ b/onchain/src/username_store/interfaces.cairo
@@ -3,6 +3,6 @@ use starknet::ContractAddress;
 #[starknet::interface]
 pub trait IUsernameStore<TContractState> {
     fn claim_username(ref self: TContractState, key: felt252);
-    fn transfer_username(ref self: TContractState, key: felt252, new_Address: ContractAddress);
+    fn change_username(ref self: TContractState, key: felt252, new_Address: ContractAddress);
     fn get_username(ref self: TContractState, key: felt252) -> ContractAddress;
 }

--- a/onchain/src/username_store/username_store.cairo
+++ b/onchain/src/username_store/username_store.cairo
@@ -18,22 +18,20 @@ pub mod UsernameStore {
     #[event]
     #[derive(Drop, starknet::Event)]
     enum Event {
-        UserNameChanged {
-            old_username: felt252,
-            new_username: felt252,
-            address: ContractAddress
-        }
+        UserNameChanged: UserNameChanged,
+        UserNameClaimed: UserNameClaimed
     }
 
     #[derive(Drop, starknet::Event)]
-    struct UserNameClaimed {
+    struct UserNameChanged {
         #[key]
-        username: felt252,
+        old_username: felt252,
+        new_username: felt252,
         address: ContractAddress
     }
 
     #[derive(Drop, starknet::Event)]
-    struct UserNameTransferred {
+    struct UserNameClaimed {
         #[key]
         username: felt252,
         address: ContractAddress


### PR DESCRIPTION
<!-- enter the gh issue after hash -->

- [x] issue #105 
- [x] follows contribution [guide](https://github.com/keep-starknet-strange/art-peace/blob/main/CONTRIBUTING.md)
- [ ] code change includes tests
- [ ] breaking change

<!-- PR description below -->
In the onchain username store, create another mapping to ensure that each user only claims one username.

Also, change the transfer_username function to a change_username function, where the user can change their username to a new one. Make sure to change the corresponding events emitted.