### PR TITLE
added feat: Quest progress bar

### DIFF
--- a/frontend/src/tabs/quests/QuestItem.css
+++ b/frontend/src/tabs/quests/QuestItem.css
@@ -67,35 +67,12 @@
   left: 0;
 
   margin: 1px;
-  width: calc(100% - 2px);
+  width: calc(100% - 2px);                        /* Default width */
   height: calc(100% - 2px);
 
-  background-color: rgba(224, 224, 224, 0.9);    /* Default bg color */
+  background-color: rgba(224, 224, 224, 0.9);   /* Default bg color */
   border-radius: 0.8rem;
   border: 0.1rem solid rgba(0, 0, 0, 0.2);
-}
-
-.QuestItem__button__progress--0 {
-  background-color: hsla(0, 100%, 60%, 0.9);
-}
-
-.QuestItem__button__progress--1 {
-  width: 25%;
-  background-color: hsla(15, 100%, 60%, 1);
-}
-
-.QuestItem__button__progress--2 {
-  width: 50%;
-  background-color: hsla(30, 100%, 60%, 1);
-}
-
-.QuestItem__button__progress--3 {
-  width: 75%;
-  background-color: hsla(45, 100%, 60%, 1);
-}
-
-.QuestItem__button__progress--4 {
-  background-color: hsla(60, 100%, 60%, 1);
 }
 
 .QuestItem__button--pulsate {

--- a/frontend/src/tabs/quests/QuestItem.css
+++ b/frontend/src/tabs/quests/QuestItem.css
@@ -70,7 +70,7 @@
   width: calc(100% - 2px);
   height: calc(100% - 2px);
 
-  background-color: rgba(224, 224, 224, 0.9);
+  background-color: rgba(224, 224, 224, 0.9);    /* Default bg color */
   border-radius: 0.8rem;
   border: 0.1rem solid rgba(0, 0, 0, 0.2);
 }

--- a/frontend/src/tabs/quests/QuestItem.css
+++ b/frontend/src/tabs/quests/QuestItem.css
@@ -41,7 +41,7 @@
   line-height: 1.3rem;
 }
 
-.QuestItem__progress {
+.QuestItem__button {
   position: relative;
   width: 7rem;
   height: 3rem;
@@ -49,17 +49,19 @@
   border-radius: 1rem;
   box-shadow: 0 0 0.5rem rgba(0, 0, 0, 0.2);
   border: 0.1rem solid rgba(0, 0, 0, 0.4);
+
+  background-color: rgba(224, 224, 224, 0.9);
 }
 
-.QuestItem__progress--claimable:hover {
+.QuestItem__button--claimable:hover {
   transform: scale(1.07) translateY(-0.15rem);
 }
 
-.QuestItem__progress--claimable:active {
+.QuestItem__button--claimable:active {
   transform: scale(1) translateY(0);
 }
 
-.QuestItem__progression {
+.QuestItem__button__progress {
   position: absolute;
   top: 0;
   left: 0;
@@ -68,32 +70,35 @@
   width: calc(100% - 2px);
   height: calc(100% - 2px);
 
-  background-color: rgba(221, 85, 51, 0.9);
+  background-color: rgba(224, 224, 224, 0.9);
   border-radius: 0.8rem;
   border: 0.1rem solid rgba(0, 0, 0, 0.2);
 }
 
-.QuestItem__progression--0 {
-  background-color: hsla(0, 100%, 60%, 1);
+.QuestItem__button__progress--0 {
+  background-color: hsla(0, 100%, 60%, 0.9);
 }
 
-.QuestItem__progression--1 {
+.QuestItem__button__progress--1 {
+  width: 25%;
   background-color: hsla(15, 100%, 60%, 1);
 }
 
-.QuestItem__progression--2 {
+.QuestItem__button__progress--2 {
+  width: 50%;
   background-color: hsla(30, 100%, 60%, 1);
 }
 
-.QuestItem__progression--3 {
+.QuestItem__button__progress--3 {
+  width: 75%;
   background-color: hsla(45, 100%, 60%, 1);
 }
 
-.QuestItem__progression--4 {
+.QuestItem__button__progress--4 {
   background-color: hsla(60, 100%, 60%, 1);
 }
 
-.QuestItem__progression--pulsate {
+.QuestItem__button--pulsate {
   animation: pulse 1s infinite;
   transition: all 0.5s ease-in;
 }

--- a/frontend/src/tabs/quests/QuestItem.css
+++ b/frontend/src/tabs/quests/QuestItem.css
@@ -47,18 +47,19 @@
   height: 3rem;
 
   border-radius: 1rem;
-  box-shadow: 0 0 0.5rem rgba(0, 0, 0, 0.2);
+  box-shadow: 0 0 0.5rem rgba(0, 0, 0, 0.3);
   border: 0.1rem solid rgba(0, 0, 0, 0.4);
-
-  background-color: rgba(224, 224, 224, 0.9);
+  transition: all 0.2s ease-in-out;
 }
 
 .QuestItem__button--claimable:hover {
-  transform: scale(1.07) translateY(-0.15rem);
+  transform: scale(1.05) translateY(-0.1rem);
+  box-shadow: 0 0 0.5rem rgba(0, 0, 0, 0.5);
 }
 
 .QuestItem__button--claimable:active {
   transform: scale(1) translateY(0);
+  box-shadow: 0 0 0.5rem rgba(0, 0, 0, 0.3);
 }
 
 .QuestItem__button__progress {
@@ -67,26 +68,38 @@
   left: 0;
 
   margin: 1px;
-  width: calc(100% - 2px);                        /* Default width */
+  width: calc(100% - 2px);
   height: calc(100% - 2px);
 
-  background-color: rgba(224, 224, 224, 0.9);   /* Default bg color */
+  background-color: rgba(224, 224, 224, 0.9);
   border-radius: 0.8rem;
-  border: 0.1rem solid rgba(0, 0, 0, 0.2);
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  overflow: hidden;
+}
+
+.QuestItem__button__progression {
+  background-color: rgba(255, 255, 255, 0.6);
+  height: 100%;
 }
 
 .QuestItem__button--pulsate {
-  animation: pulse 1s infinite;
-  transition: all 0.5s ease-in;
+  animation: pulse 1.5s infinite;
 }
 
 @keyframes pulse {
   0%,
+  40%,
+  80%,
   100% {
-    transform: scale(1);
+    box-shadow: 0 0 0.3rem rgba(0, 0, 0, 0.5);
+    background-color: rgba(100, 100, 200, 0.4);
+    scale: 1;
   }
-  25% {
-    transform: scale(1.075);
+  20%,
+  60% {
+    box-shadow: 0 0 0.7rem rgba(0, 0, 0, 0.5);
+    background-color: rgba(100, 100, 100, 0.2);
+    scale: 1.02;
   }
 }
 

--- a/frontend/src/tabs/quests/QuestItem.css
+++ b/frontend/src/tabs/quests/QuestItem.css
@@ -73,6 +73,40 @@
   border: 0.1rem solid rgba(0, 0, 0, 0.2);
 }
 
+.QuestItem__progression--0 {
+  background-color: hsla(0, 100%, 60%, 1);
+}
+
+.QuestItem__progression--1 {
+  background-color: hsla(15, 100%, 60%, 1);
+}
+
+.QuestItem__progression--2 {
+  background-color: hsla(30, 100%, 60%, 1);
+}
+
+.QuestItem__progression--3 {
+  background-color: hsla(45, 100%, 60%, 1);
+}
+
+.QuestItem__progression--4 {
+  background-color: hsla(60, 100%, 60%, 1);
+}
+
+.QuestItem__progression--pulsate {
+  animation: pulse 1s infinite;
+  transition: all 0.5s ease-in;
+}
+
+@keyframes pulse {
+    0%, 100% {
+        transform: scale(1);
+    }
+    25% {
+        transform: scale(1.075);
+    }
+}
+
 .QuestItem__progression--completed {
   background-color: rgba(85, 221, 51, 0.9);
 }

--- a/frontend/src/tabs/quests/QuestItem.css
+++ b/frontend/src/tabs/quests/QuestItem.css
@@ -99,12 +99,13 @@
 }
 
 @keyframes pulse {
-    0%, 100% {
-        transform: scale(1);
-    }
-    25% {
-        transform: scale(1.075);
-    }
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  25% {
+    transform: scale(1.075);
+  }
 }
 
 .QuestItem__progression--completed {

--- a/frontend/src/tabs/quests/QuestItem.js
+++ b/frontend/src/tabs/quests/QuestItem.js
@@ -115,11 +115,14 @@ const QuestItem = (props) => {
   };
 
   let progress;
-  // progress cannot be more than needed. So if it is, it will set our progress to -1.
+  // progress cannot be more than needed. So if it is, it will set our progress to 100.
   if (props.progress > props.needed) {
-    progress = -1;
+    progress = 100;
   } else {
-    progress = Math.floor((props.progress / props.needed) * 4);
+    // progress being less than 20 makes
+    // the progress bar look weird so clamping it to inclusive range [20, 100].
+    progress = (props.progress / props.needed) * 100;
+    progress = progress < 20 ? 20 : progress;
   }
 
   return (
@@ -146,10 +149,11 @@ const QuestItem = (props) => {
           }
         >
           <div
-            className={
-              'QuestItem__button__progress ' +
-              `QuestItem__button__progress--${progress} `
-            }
+            className={'QuestItem__button__progress'}
+            style={{
+              width: `calc(${progress}% - 2px)`,
+              backgroundColor: `hsla(${(progress / 100) * 60}, 100%, 60%, 1)`
+            }}
             onClick={claimOrExpand}
           ></div>
           <div className='Text__xsmall QuestItem__reward'>

--- a/frontend/src/tabs/quests/QuestItem.js
+++ b/frontend/src/tabs/quests/QuestItem.js
@@ -114,14 +114,13 @@ const QuestItem = (props) => {
     // TODO: Expand if not claimable && has args
   };
 
-  if (props.progress == 0) {
-    console.log(
-      props.progress ? `QuestItem__button__progress--${props.progress} ` : ''
-    );
+  let progress;
+  // progress cannot be more than needed. So if it is, it will set our progress to -1.
+  if (props.progress > props.needed) {
+    progress = -1;
+  } else {
+    progress = Math.floor((props.progress / props.needed) * 4);
   }
-
-  const progress = Math.floor((props.progress / props.needed) * 4);
-  console.log(props.progress, props.needed, progress);
 
   return (
     <div

--- a/frontend/src/tabs/quests/QuestItem.js
+++ b/frontend/src/tabs/quests/QuestItem.js
@@ -120,6 +120,9 @@ const QuestItem = (props) => {
     );
   }
 
+  const progress = Math.floor((props.progress / props.needed) * 4);
+  console.log(props.progress, props.needed, progress);
+
   return (
     <div
       className={
@@ -140,15 +143,13 @@ const QuestItem = (props) => {
             (props.status != 'completed'
               ? 'QuestItem__button--claimable '
               : '') +
-            (props.progress && props.progress == 4
-              ? 'QuestItem__button--pulsate '
-              : '')
+            (progress == 4 ? 'QuestItem__button--pulsate ' : '')
           }
         >
           <div
             className={
               'QuestItem__button__progress ' +
-              `QuestItem__button__progress--${props.progress} `
+              `QuestItem__button__progress--${progress} `
             }
             onClick={claimOrExpand}
           ></div>

--- a/frontend/src/tabs/quests/QuestItem.js
+++ b/frontend/src/tabs/quests/QuestItem.js
@@ -145,7 +145,7 @@ const QuestItem = (props) => {
             (props.status != 'completed'
               ? 'QuestItem__button--claimable '
               : '') +
-            (progress == 4 ? 'QuestItem__button--pulsate ' : '')
+            (progress == 100 ? 'QuestItem__button--pulsate ' : '')
           }
         >
           <div

--- a/frontend/src/tabs/quests/QuestItem.js
+++ b/frontend/src/tabs/quests/QuestItem.js
@@ -114,6 +114,12 @@ const QuestItem = (props) => {
     // TODO: Expand if not claimable && has args
   };
 
+  if (props.progress == 0) {
+    console.log(
+      props.progress ? `QuestItem__button__progress--${props.progress} ` : ''
+    );
+  }
+
   return (
     <div
       className={
@@ -130,21 +136,19 @@ const QuestItem = (props) => {
         </div>
         <div
           className={
-            'QuestItem__progress ' +
+            'QuestItem__button ' +
             (props.status != 'completed'
-              ? 'QuestItem__progress--claimable '
+              ? 'QuestItem__button--claimable '
               : '') +
             (props.progress && props.progress == 4
-              ? 'QuestItem__progression--pulsate '
+              ? 'QuestItem__button--pulsate '
               : '')
           }
         >
           <div
             className={
-              `QuestItem__progression ` +
-              (props.progress
-                ? `QuestItem__progression--${props.progress} `
-                : '')
+              'QuestItem__button__progress ' +
+              `QuestItem__button__progress--${props.progress} `
             }
             onClick={claimOrExpand}
           ></div>

--- a/frontend/src/tabs/quests/QuestItem.js
+++ b/frontend/src/tabs/quests/QuestItem.js
@@ -132,12 +132,20 @@ const QuestItem = (props) => {
           className={
             'QuestItem__progress ' +
             (props.status != 'completed'
-              ? 'QuestItem__progress--claimable'
+              ? 'QuestItem__progress--claimable '
+              : '') +
+            (props.progress && props.progress == 4
+              ? 'QuestItem__progression--pulsate '
               : '')
           }
         >
           <div
-            className={`QuestItem__progression QuestItem__progression--${props.status}`}
+            className={
+              `QuestItem__progression ` +
+              (props.progress
+                ? `QuestItem__progression--${props.progress} `
+                : '')
+            }
             onClick={claimOrExpand}
           ></div>
           <div className='Text__xsmall QuestItem__reward'>

--- a/frontend/src/tabs/quests/Quests.js
+++ b/frontend/src/tabs/quests/Quests.js
@@ -145,6 +145,7 @@ const Quests = (props) => {
             markCompleted={markCompleted}
             address={props.address}
             artPeaceContract={props.artPeaceContract}
+            progress={4}
           />
         ))}
 
@@ -161,6 +162,7 @@ const Quests = (props) => {
             markCompleted={markCompleted}
             address={props.address}
             artPeaceContract={props.artPeaceContract}
+            progress={0}
           />
         ))}
       </div>

--- a/frontend/src/tabs/quests/Quests.js
+++ b/frontend/src/tabs/quests/Quests.js
@@ -29,14 +29,16 @@ const Quests = (props) => {
         'Add 10 pixels on the canvas [art/peace theme](https://www.google.com/)',
       reward: '3',
       status: 'incomplete',
-      progress: 0
+      progress: 0,
+      needed: 13
     },
     {
       name: 'Build a template',
       description: 'Create a template for the community to use',
       reward: '3',
       status: 'claim',
-      progress: 1
+      progress: 3,
+      needed: 13
     },
     {
       name: 'Deploy a Memecoin',
@@ -44,7 +46,8 @@ const Quests = (props) => {
       reward: '10',
       status: 'incomplete',
       args: createArgs(['MemeCoin Address'], ['0x1234'], ['address']),
-      progress: 2
+      progress: 6,
+      needed: 13
     }
   ];
 
@@ -59,21 +62,24 @@ const Quests = (props) => {
         ['@test', '0x1234', 'asdioj'],
         ['twitter', 'address', 'text']
       ),
-      progress: 3
+      progress: 9,
+      needed: 13
     },
     {
       name: 'Place 100 pixels',
       description: 'Add 100 pixels on the canvas',
       reward: '10',
       status: 'completed',
-      progress: 4
+      progress: 12,
+      needed: 13
     },
     {
       name: 'Mint art/peace NFT',
       description: 'Mint an NFT using the art/peace theme',
       reward: '5',
       status: 'incomplete',
-      progress: 5
+      progress: 13,
+      needed: 13
     }
   ];
 
@@ -154,6 +160,7 @@ const Quests = (props) => {
             address={props.address}
             artPeaceContract={props.artPeaceContract}
             progress={quest.progress}
+            needed={quest.needed}
           />
         ))}
 
@@ -171,6 +178,7 @@ const Quests = (props) => {
             address={props.address}
             artPeaceContract={props.artPeaceContract}
             progress={quest.progress}
+            needed={quest.needed}
           />
         ))}
       </div>

--- a/frontend/src/tabs/quests/Quests.js
+++ b/frontend/src/tabs/quests/Quests.js
@@ -28,26 +28,26 @@ const Quests = (props) => {
       description:
         'Add 10 pixels on the canvas [art/peace theme](https://www.google.com/)',
       reward: '3',
-      status: 'incomplete',
+      completed: false,
       progress: 0,
-      needed: 13
+      needed: 10
     },
     {
       name: 'Build a template',
       description: 'Create a template for the community to use',
       reward: '3',
-      status: 'claim',
-      progress: 3,
-      needed: 13
+      completed: false,
+      progress: 1,
+      needed: 20
     },
     {
       name: 'Deploy a Memecoin',
       description: 'Create an Unruggable memecoin',
       reward: '10',
-      status: 'incomplete',
+      completed: false,
       args: createArgs(['MemeCoin Address'], ['0x1234'], ['address']),
-      progress: 6,
-      needed: 13
+      progress: 1,
+      needed: 1
     }
   ];
 
@@ -56,28 +56,28 @@ const Quests = (props) => {
       name: 'Tweet #art/peace',
       description: 'Tweet about art/peace using the hashtag & addr',
       reward: '10',
-      status: 'incomplete',
+      completed: true,
       args: createArgs(
         ['Twitter Handle', 'Address', 'test'],
         ['@test', '0x1234', 'asdioj'],
         ['twitter', 'address', 'text']
       ),
-      progress: 9,
+      progress: 13,
       needed: 13
     },
     {
       name: 'Place 100 pixels',
       description: 'Add 100 pixels on the canvas',
       reward: '10',
-      status: 'completed',
-      progress: 12,
-      needed: 13
+      completed: false,
+      progress: 98,
+      needed: 100
     },
     {
       name: 'Mint art/peace NFT',
       description: 'Mint an NFT using the art/peace theme',
       reward: '5',
-      status: 'incomplete',
+      completed: false,
       progress: 14,
       needed: 13
     }

--- a/frontend/src/tabs/quests/Quests.js
+++ b/frontend/src/tabs/quests/Quests.js
@@ -95,7 +95,6 @@ const Quests = (props) => {
         if (!dailyData) {
           dailyData = localDailyQuests;
         }
-        dailyData = localDailyQuests;
         setTodaysQuests(sortByCompleted(dailyData));
 
         // Fetching main quests from backend
@@ -108,7 +107,6 @@ const Quests = (props) => {
           // TODO: remove this & use []
           mainData = localMainQuests;
         }
-        mainData = localMainQuests;
         setMainQuests(sortByCompleted(mainData));
       } catch (error) {
         console.error('Failed to fetch quests', error);

--- a/frontend/src/tabs/quests/Quests.js
+++ b/frontend/src/tabs/quests/Quests.js
@@ -78,7 +78,7 @@ const Quests = (props) => {
       description: 'Mint an NFT using the art/peace theme',
       reward: '5',
       status: 'incomplete',
-      progress: 13,
+      progress: 14,
       needed: 13
     }
   ];
@@ -95,7 +95,6 @@ const Quests = (props) => {
         if (!dailyData) {
           dailyData = localDailyQuests;
         }
-        dailyData = localDailyQuests;
         setTodaysQuests(sortByCompleted(dailyData));
 
         // Fetching main quests from backend
@@ -108,7 +107,6 @@ const Quests = (props) => {
           // TODO: remove this & use []
           mainData = localMainQuests;
         }
-        mainData = localMainQuests;
         setMainQuests(sortByCompleted(mainData));
       } catch (error) {
         console.error('Failed to fetch quests', error);

--- a/frontend/src/tabs/quests/Quests.js
+++ b/frontend/src/tabs/quests/Quests.js
@@ -95,6 +95,7 @@ const Quests = (props) => {
         if (!dailyData) {
           dailyData = localDailyQuests;
         }
+        dailyData = localDailyQuests;
         setTodaysQuests(sortByCompleted(dailyData));
 
         // Fetching main quests from backend
@@ -107,6 +108,7 @@ const Quests = (props) => {
           // TODO: remove this & use []
           mainData = localMainQuests;
         }
+        mainData = localMainQuests;
         setMainQuests(sortByCompleted(mainData));
       } catch (error) {
         console.error('Failed to fetch quests', error);

--- a/frontend/src/tabs/quests/Quests.js
+++ b/frontend/src/tabs/quests/Quests.js
@@ -24,24 +24,27 @@ const Quests = (props) => {
 
   const localDailyQuests = [
     {
-      title: 'Place 10 pixels',
+      name: 'Place 10 pixels',
       description:
         'Add 10 pixels on the canvas [art/peace theme](https://www.google.com/)',
       reward: '3',
-      status: 'completed'
+      status: 'incomplete',
+      progress: 0
     },
     {
       name: 'Build a template',
       description: 'Create a template for the community to use',
       reward: '3',
-      status: 'claim'
+      status: 'claim',
+      progress: 1
     },
     {
       name: 'Deploy a Memecoin',
       description: 'Create an Unruggable memecoin',
       reward: '10',
       status: 'incomplete',
-      args: createArgs(['MemeCoin Address'], ['0x1234'], ['address'])
+      args: createArgs(['MemeCoin Address'], ['0x1234'], ['address']),
+      progress: 2
     }
   ];
 
@@ -55,19 +58,22 @@ const Quests = (props) => {
         ['Twitter Handle', 'Address', 'test'],
         ['@test', '0x1234', 'asdioj'],
         ['twitter', 'address', 'text']
-      )
+      ),
+      progress: 3
     },
     {
       name: 'Place 100 pixels',
       description: 'Add 100 pixels on the canvas',
       reward: '10',
-      status: 'completed'
+      status: 'completed',
+      progress: 4
     },
     {
       name: 'Mint art/peace NFT',
       description: 'Mint an NFT using the art/peace theme',
       reward: '5',
-      status: 'incomplete'
+      status: 'incomplete',
+      progress: 5
     }
   ];
 
@@ -83,6 +89,7 @@ const Quests = (props) => {
         if (!dailyData) {
           dailyData = localDailyQuests;
         }
+        dailyData = localDailyQuests;
         setTodaysQuests(sortByCompleted(dailyData));
 
         // Fetching main quests from backend
@@ -95,6 +102,7 @@ const Quests = (props) => {
           // TODO: remove this & use []
           mainData = localMainQuests;
         }
+        mainData = localMainQuests;
         setMainQuests(sortByCompleted(mainData));
       } catch (error) {
         console.error('Failed to fetch quests', error);
@@ -145,7 +153,7 @@ const Quests = (props) => {
             markCompleted={markCompleted}
             address={props.address}
             artPeaceContract={props.artPeaceContract}
-            progress={4}
+            progress={quest.progress}
           />
         ))}
 
@@ -162,7 +170,7 @@ const Quests = (props) => {
             markCompleted={markCompleted}
             address={props.address}
             artPeaceContract={props.artPeaceContract}
-            progress={0}
+            progress={quest.progress}
           />
         ))}
       </div>


### PR DESCRIPTION
<!-- enter the gh issue after hash -->

- [x] issue #175 
- [x] follows contribution [guide](https://github.com/keep-starknet-strange/art-peace/blob/main/CONTRIBUTING.md)
- [ ] code change includes tests
- [ ] breaking change

<!-- PR description below -->
Adds a prop for `progress` which is inclusive [0,4] where 0 is for no progress and 4 is for claimable. Have made to change the background-color from hue 0 (red) to hue 60 (yellow) for progress 0 -> 4. Also, the button pulsates when `progress` will be 4. closes Issue #175 

I did not find any need for `needed`, but let me know what it will be used for or if there will be any TODO on it. I will be happy to take it :)