### PR TITLE
feat: implement template image size and hash check

### DIFF
--- a/onchain/src/art_peace.cairo
+++ b/onchain/src/art_peace.cairo
@@ -1,6 +1,7 @@
 #[starknet::contract]
 pub mod ArtPeace {
-    use core::traits::Into;
+    use core::traits::TryInto;
+use core::traits::Into;
     use starknet::ContractAddress;
     use core::poseidon::PoseidonTrait;
     use core::hash::{HashStateTrait, HashStateExTrait};
@@ -970,15 +971,20 @@ pub mod ArtPeace {
             assert(template_id < self.get_templates_count(), 'Template ID out of bounds');
             assert(!self.is_template_complete(template_id), 'Template already completed');
             // TODO: ensure template_image matches the template size & hash
-            let template_hash = compute_template_hash(template_image);
-            assert(template_hash == template_image, 'Template Image Hash is the same');
+            let template_hash = self.compute_template_hash(template_image);
+            let  template_image_value = *template_image.at(0);
+
+            let template_image_value: felt252 = template_image_value.into();
+
+            assert(template_hash == template_image_value, 'Template Image Hash is the same');
 
             let template_store: TemplateMetadata = self.templates.templates.read(template_id);
 
             let onchain_template_length: u128 = template_store.width * template_store.height;
+            let template_image_value: u128 = template_image_value.try_into().unwrap();
 
             assert(
-                onchain_template_length == template_image.into(), 'Template Image Hash is the same'
+                onchain_template_length == template_image_value, 'Template Image Hash is the same'
             );
 
             let template_metadata: TemplateMetadata = self.get_template(template_id);

--- a/onchain/src/templates/interfaces.cairo
+++ b/onchain/src/templates/interfaces.cairo
@@ -33,5 +33,5 @@ pub trait ITemplateVerifier<TContractState> {
     // If there was a reward escrowed, it is transferred to the builders.
     // Passed template_image contains the full image, and is used to verify the template.
     fn complete_template(ref self: TContractState, template_id: u32, template_image: Span<u8>);
-    fn compute_template_hash(ref self: TContractState, template: Span<u8>) -> felt252;
+    fn compute_template_hash(self: @TContractState, template: Span<u8>) -> felt252;
 }

--- a/onchain/src/templates/interfaces.cairo
+++ b/onchain/src/templates/interfaces.cairo
@@ -33,4 +33,5 @@ pub trait ITemplateVerifier<TContractState> {
     // If there was a reward escrowed, it is transferred to the builders.
     // Passed template_image contains the full image, and is used to verify the template.
     fn complete_template(ref self: TContractState, template_id: u32, template_image: Span<u8>);
+    fn compute_template_hash(ref self: TContractState, template: Span<u8>) -> felt252;
 }

--- a/onchain/src/tests/art_peace.cairo
+++ b/onchain/src/tests/art_peace.cairo
@@ -185,21 +185,21 @@ pub(crate) fn warp_to_next_available_time(art_peace: IArtPeaceDispatcher) {
     );
 }
 
-// fn compute_template_hash(template: Span<u8>) -> felt252 {
-//     let template_len = template.len();
-//     if template_len == 0 {
-//         return 0;
-//     }
+fn compute_template_hash(template: Span<u8>) -> felt252 {
+    let template_len = template.len();
+    if template_len == 0 {
+        return 0;
+    }
 
-//     let mut hasher = PoseidonTrait::new();
-//     let mut i = 0;
-//     while i < template_len {
-//         hasher = hasher.update_with(*template.at(i));
-//         i += 1;
-//     };
+    let mut hasher = PoseidonTrait::new();
+    let mut i = 0;
+    while i < template_len {
+        hasher = hasher.update_with(*template.at(i));
+        i += 1;
+    };
 
-//     hasher.finalize()
-// }
+    hasher.finalize()
+}
 
 #[test]
 fn deploy_test() {
@@ -404,7 +404,7 @@ fn deposit_reward_test() {
 
     // 2x2 template image
     let template_image = array![1, 2, 3, 4];
-    let template_hash = compute_template_hash(template_image.span());
+    let template_hash = template_verifier.compute_template_hash(template_image.span());
     let template_metadata = TemplateMetadata {
         name: 'test',
         hash: template_hash,
@@ -414,7 +414,7 @@ fn deposit_reward_test() {
         reward: reward_amount,
         reward_token: erc20_mock,
         creator: get_caller_address(),
-    };
+    };        
 
     IERC20Dispatcher { contract_address: erc20_mock }.approve(art_peace_address, reward_amount);
 

--- a/onchain/src/tests/art_peace.cairo
+++ b/onchain/src/tests/art_peace.cairo
@@ -185,21 +185,21 @@ pub(crate) fn warp_to_next_available_time(art_peace: IArtPeaceDispatcher) {
     );
 }
 
-fn compute_template_hash(template: Span<u8>) -> felt252 {
-    let template_len = template.len();
-    if template_len == 0 {
-        return 0;
-    }
+// fn compute_template_hash(template: Span<u8>) -> felt252 {
+//     let template_len = template.len();
+//     if template_len == 0 {
+//         return 0;
+//     }
 
-    let mut hasher = PoseidonTrait::new();
-    let mut i = 0;
-    while i < template_len {
-        hasher = hasher.update_with(*template.at(i));
-        i += 1;
-    };
+//     let mut hasher = PoseidonTrait::new();
+//     let mut i = 0;
+//     while i < template_len {
+//         hasher = hasher.update_with(*template.at(i));
+//         i += 1;
+//     };
 
-    hasher.finalize()
-}
+//     hasher.finalize()
+// }
 
 #[test]
 fn deploy_test() {
@@ -253,7 +253,7 @@ fn template_full_basic_test() {
 
     // 2x2 template image
     let template_image = array![1, 2, 3, 4];
-    let template_hash = compute_template_hash(template_image.span());
+    let template_hash = template_verifier.compute_template_hash(template_image.span());
     let template_metadata = TemplateMetadata {
         name: 'test',
         hash: template_hash,

--- a/onchain/src/tests/art_peace.cairo
+++ b/onchain/src/tests/art_peace.cairo
@@ -404,7 +404,7 @@ fn deposit_reward_test() {
 
     // 2x2 template image
     let template_image = array![1, 2, 3, 4];
-    let template_hash = template_verifier.compute_template_hash(template_image.span());
+    let template_hash = compute_template_hash(template_image.span());
     let template_metadata = TemplateMetadata {
         name: 'test',
         hash: template_hash,


### PR DESCRIPTION
<!-- enter the gh issue after hash -->

- [X] issue #148
- [X] follows contribution [guide](https://github.com/keep-starknet-strange/art-peace/blob/main/CONTRIBUTING.md)
- [X] code change includes tests
- [X] breaking change

<!-- PR description below -->
This is a draft of my attempt on the Template image size and hash check.
The program is yet compile 

complier error: `compute_template_hash(template_image)` not found.
Whereas this function is defined above where it was called in same file