### PR TITLE
Award scripts & Nft directory based on Round

### DIFF
--- a/backend/routes/indexer/nft.go
+++ b/backend/routes/indexer/nft.go
@@ -170,24 +170,36 @@ func processNFTMintedEvent(event IndexerEvent) {
 		}
 	}
 
-	if _, err := os.Stat("nfts/images"); os.IsNotExist(err) {
-		err = os.MkdirAll("nfts/images", os.ModePerm)
+	roundDir := fmt.Sprintf("nfts/round-%d", dayIndex/7+1)
+	if _, err := os.Stat(roundDir); os.IsNotExist(err) {
+		err = os.MkdirAll(roundDir, os.ModePerm)
 		if err != nil {
-			PrintIndexerError("processNFTMintedEvent", "Error creating nfts/images directory", tokenIdLowHex, positionHex, widthHex, heightHex, nameHex, imageHashHex, blockNumberHex, minter)
+			PrintIndexerError("processNFTMintedEvent", "Error creating round directory", tokenIdLowHex, positionHex, widthHex, heightHex, nameHex, imageHashHex, blockNumberHex, minter)
 			return
 		}
 	}
 
-	if _, err := os.Stat("nfts/meta"); os.IsNotExist(err) {
-		err = os.MkdirAll("nfts/meta", os.ModePerm)
+	imagesDir := fmt.Sprintf("%s/images", roundDir)
+	if _, err := os.Stat(imagesDir); os.IsNotExist(err) {
+		err = os.MkdirAll(imagesDir, os.ModePerm)
 		if err != nil {
-			PrintIndexerError("processNFTMintedEvent", "Error creating nfts/meta directory", tokenIdLowHex, positionHex, widthHex, heightHex, nameHex, imageHashHex, blockNumberHex, minter)
+			PrintIndexerError("processNFTMintedEvent", "Error creating images directory", tokenIdLowHex, positionHex, widthHex, heightHex, nameHex, imageHashHex, blockNumberHex, minter)
 			return
 		}
 	}
+
+	metaDir := fmt.Sprintf("%s/meta", roundDir)
+	if _, err := os.Stat(metaDir); os.IsNotExist(err) {
+		err = os.MkdirAll(metaDir, os.ModePerm)
+		if err != nil {
+			PrintIndexerError("processNFTMintedEvent", "Error creating meta directory", tokenIdLowHex, positionHex, widthHex, heightHex, nameHex, imageHashHex, blockNumberHex, minter)
+			return
+		}
+	}
+
 
 	// Save image to disk
-	filename := fmt.Sprintf("nfts/images/nft-%d.png", tokenId)
+	filename := fmt.Sprintf("%s/nft-%d.png", imagesDir, tokenId)
 	file, err := os.Create(filename)
 	if err != nil {
 		PrintIndexerError("processNFTMintedEvent", "Error creating file", tokenIdLowHex, tokenIdHighHex, positionHex, widthHex, heightHex, nameHex, imageHashHex, blockNumberHex, minter)
@@ -242,7 +254,7 @@ func processNFTMintedEvent(event IndexerEvent) {
 		return
 	}
 
-	metadataFilename := fmt.Sprintf("nfts/meta/nft-%d.json", tokenId)
+	metadataFilename := fmt.Sprintf("%s/nft-%d.json", metaDir, tokenId)
 	err = os.WriteFile(metadataFilename, metadataFile, 0644)
 	if err != nil {
 		PrintIndexerError("processNFTMintedEvent", "Error writing NFT metadata file", tokenIdLowHex, positionHex, widthHex, heightHex, nameHex, imageHashHex, blockNumberHex, minter)

--- a/frontend/src/configs/backend.config.json
+++ b/frontend/src/configs/backend.config.json
@@ -1,15 +1,30 @@
 {
-  "host": "api.art-peace.net",
+  "host": "localhost",
   "port": 8080,
+  "consumer_port": 8081,
   "scripts": {
     "place_pixel_devnet": "../tests/integration/local/place_pixel.sh",
     "place_extra_pixels_devnet": "../tests/integration/local/place_extra_pixels.sh",
     "add_template_devnet": "../tests/integration/local/add_template.sh",
-    "mint_nft_devnet": "../tests/integration/local/mint_nft.sh"
+    "mint_nft_devnet": "../tests/integration/local/mint_nft.sh",
+    "like_nft_devnet": "../tests/integration/local/like_nft.sh",
+    "unlike_nft_devnet": "../tests/integration/local/unlike_nft.sh",
+    "vote_color_devnet": "../tests/integration/local/vote_color.sh",
+    "increase_day_devnet": "../tests/integration/local/increase_day_index.sh",
+    "join_chain_faction_devnet": "../tests/integration/local/join_chain_faction.sh",
+    "join_faction_devnet": "../tests/integration/local/join_faction.sh",
+    "leave_faction_devnet": "../tests/integration/local/leave_faction.sh",
+    "add_faction_template_devnet": "../tests/integration/local/add_faction_template.sh",
+    "remove_faction_template_devnet": "../tests/integration/local/remove_faction_template.sh"
   },
-  "production": true,
+  "production": false,
   "websocket": {
     "read_buffer_size": 1024,
     "write_buffer_size": 1024
+  },
+  "http_config": {
+    "allow_origin": ["*"],
+    "allow_methods": ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+    "allow_headers": ["Content-Type"]
   }
 }

--- a/scripts/rewards/docker-reward.sh
+++ b/scripts/rewards/docker-reward.sh
@@ -1,8 +1,23 @@
 #!/bin/bash
 ENVIRONMENT="docker"
 NETWORK="docker"
-ART_PEACE_CONTRACT="" # Add contract address
+ART_PEACE_CONTRACT="0x1ab2cbeca04513431467026958fe15833ae4fb7dfd2466043161dc02a2efb7a"
 
-export STARKNET_RPC="http://localhost:5050"
+# Set up account variables
+TIMESTAMP=$(date +%s)
+TMP_DIR=$HOME/.art-peace-tests/tmp/$TIMESTAMP
+mkdir -p $TMP_DIR
+
+ACCOUNT_NAME=art_peace_acct
+ACCOUNT_ADDRESS=0x328ced46664355fc4b885ae7011af202313056a7e3d44827fb24c9d3206aaa0
+ACCOUNT_PRIVATE_KEY=0x856c96eaa4e7c40c715ccc5dacd8bf6e
+ACCOUNT_FILE=$TMP_DIR/starknet_accounts.json
+export RPC_URL="http://localhost:5050"
+
+# Add the test account credentials
+sncast --url $RPC_URL --accounts-file $ACCOUNT_FILE account add \
+    --name $ACCOUNT_NAME \
+    --address $ACCOUNT_ADDRESS \
+    --private-key $ACCOUNT_PRIVATE_KEY
 
 source "$(dirname "$0")/reward.sh" "$1"

--- a/scripts/rewards/docker-reward.sh
+++ b/scripts/rewards/docker-reward.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+ENVIRONMENT="docker"
+RPC_URL="http://localhost:5050"
+ACCOUNT_FILE="~/.art-peace-tests/tmp/starknet_accounts.json"
+ACCOUNT_NAME="art_peace_acct"
+ART_PEACE_CONTRACT="" # Add contract address
+
+source "$(dirname "$0")/reward.sh" "$1"

--- a/scripts/rewards/docker-reward.sh
+++ b/scripts/rewards/docker-reward.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 ENVIRONMENT="docker"
-RPC_URL="http://localhost:5050"
-ACCOUNT_FILE="~/.art-peace-tests/tmp/starknet_accounts.json"
-ACCOUNT_NAME="art_peace_acct"
+NETWORK="docker"
 ART_PEACE_CONTRACT="" # Add contract address
+
+export STARKNET_RPC="http://localhost:5050"
 
 source "$(dirname "$0")/reward.sh" "$1"

--- a/scripts/rewards/mainnet-reward.sh
+++ b/scripts/rewards/mainnet-reward.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+ENVIRONMENT="mainnet"
+NETWORK="mainnet"
+ART_PEACE_CONTRACT="0x067883deb1c1cb60756eb6e60d500081352441a040d5039d0e4ce9fed35d68c1"
+
+export STARKNET_RPC="https://starknet-mainnet.public.blastapi.io"
+
+source "$(dirname "$0")/reward.sh" "$1"

--- a/scripts/rewards/reward.sh
+++ b/scripts/rewards/reward.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+# Check if JSON file is provided
+if [ -z "$1" ]; then
+  echo "Usage: $0 <rewards.json>"
+  exit 1
+fi
+
+REWARDS_FILE=$1
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+PROJECT_ROOT=$SCRIPT_DIR/../..
+
+# Check if required commands exist
+command -v jq >/dev/null 2>&1 || { echo "Error: jq is required but not installed. Please install jq first using 'brew install jq'"; exit 1; }
+
+# Check if rewards file exists and is valid JSON
+if [ ! -f "$REWARDS_FILE" ]; then
+    echo "Error: Rewards file not found at: $REWARDS_FILE"
+    echo "Please create a rewards.json file with the following format:"
+    echo '{
+        "rewards": [
+            {
+                "address": "0x123...",
+                "amount": 10
+            }
+        ]
+    }'
+    exit 1
+fi
+
+# Validate environment variables
+if [ "$ENVIRONMENT" = "docker" ]; then
+    if [ -z "$RPC_URL" ] || [ -z "$ACCOUNT_FILE" ] || [ -z "$ACCOUNT_NAME" ]; then
+        echo "Error: Docker environment variables not set"
+        exit 1
+    fi
+else
+    if [ -z "$STARKNET_KEYSTORE" ]; then
+        echo "Error: STARKNET_KEYSTORE is not set"
+        exit 1
+    elif [ -z "$STARKNET_ACCOUNT" ]; then
+        echo "Error: STARKNET_ACCOUNT is not set"
+        exit 1
+    fi
+fi
+
+# Read and process rewards JSON
+REWARDS=$(cat $REWARDS_FILE | jq -r '.rewards[] | "\(.address) \(.amount)"')
+
+while IFS= read -r line; do
+    if [ -z "$line" ]; then
+        continue
+    fi
+    
+    ADDRESS=$(echo $line | cut -d' ' -f1)
+    AMOUNT=$(echo $line | cut -d' ' -f2)
+    
+    echo "Awarding $AMOUNT pixels to $ADDRESS..."
+    
+    # Call contract based on environment
+    if [ "$ENVIRONMENT" = "docker" ]; then
+        echo "Running docker command:"
+        echo "sncast --account $ACCOUNT_NAME call --url $RPC_URL --contract-address $ART_PEACE_CONTRACT --function host_award_user --calldata $ADDRESS $AMOUNT"
+        sncast --account $ACCOUNT_NAME \
+            call \
+            --url $RPC_URL \
+            --contract-address $ART_PEACE_CONTRACT \
+            --function host_award_user \
+            --calldata $ADDRESS $AMOUNT \
+            --block-id latest
+    else
+        echo "Running starkli command:"
+        echo "starkli invoke $ART_PEACE_CONTRACT host_award_user $ADDRESS $AMOUNT --network $NETWORK --keystore $STARKNET_KEYSTORE --account $STARKNET_ACCOUNT --watch"
+        if ! starkli invoke $ART_PEACE_CONTRACT host_award_user $ADDRESS $AMOUNT \
+            --network $NETWORK --keystore $STARKNET_KEYSTORE --account $STARKNET_ACCOUNT --watch; then
+            echo "Error: Failed to award pixels. Make sure:"
+            echo "1. The contract address is correct: $ART_PEACE_CONTRACT"
+            echo "2. Your account has host privileges"
+            echo "3. The address format is correct: $ADDRESS"
+            echo "4. The amount is valid: $AMOUNT"
+            exit 1
+        fi
+    fi
+done <<< "$REWARDS"

--- a/scripts/rewards/sample-rewards.json
+++ b/scripts/rewards/sample-rewards.json
@@ -1,0 +1,12 @@
+{
+    "rewards": [
+      {
+        "address": "0x05e01dB693CBF7461a016343042786DaC5A6000104813cF134a1E8B1D0a6810b",
+        "amount": 10
+      },
+      {
+        "address": "0x05e01dB693CBF7461a016343042786DaC5A6000104813cF134a1E8B1D0a6810b", 
+        "amount": 5
+      }
+    ]
+  }

--- a/scripts/rewards/sepolia-reward.sh
+++ b/scripts/rewards/sepolia-reward.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+ENVIRONMENT="sepolia" 
+NETWORK="sepolia"
+ART_PEACE_CONTRACT="0x078f4e772300472a68a19f2b1aedbcb7cf2acd6f67a2236372310a528c7eaa67"
+
+export STARKNET_RPC="https://starknet-sepolia.public.blastapi.io"
+
+source "$(dirname "$0")/reward.sh" "$1"


### PR DESCRIPTION
<!-- enter the gh issue after hash -->

- [ ] issue #
- [ ] follows contribution [guide](https://github.com/keep-starknet-strange/art-peace/blob/main/CONTRIBUTING.md)
- [ ] code change includes tests
- [ ] breaking change

<!-- PR description below -->
To reach this scripts you have to run
`cd scripts/rewards`
To run let's say award script on sepolia you simply call the sepolia-rewards.sh and pass a path to a json file containing all the addresses and amounts you want to reward as defined in `sample-reward.json`
An example is:
`./award_on_local.sh sample-rewards.json`
*DO NOT FORGET TO SETUP YOUR ENVIRONMENT TO HAVE STARKNET_KEYSTORE AND STARKNET_ACCOUNT (in a .env file in root directory)*
Then to upload nft data to folders based on round, do not forget to modify `ROUND_NUMBER=` in docker-compose.yaml